### PR TITLE
fix(ipv4): broaden public range generation to only check is_global

### DIFF
--- a/backend/api_applications/discovery/scanner.py
+++ b/backend/api_applications/discovery/scanner.py
@@ -20,13 +20,7 @@ logging.basicConfig(
 def generate_public_ipv4_ranges_stream(cidr_prefix=24):
     all_space = ipaddress.IPv4Network("0.0.0.0/0")
     for subnet in all_space.subnets(new_prefix=cidr_prefix):
-        if subnet.is_global and not (
-            subnet.is_private
-            or subnet.is_loopback
-            or subnet.is_link_local
-            or subnet.is_multicast
-            or subnet.is_reserved
-        ):
+        if subnet.is_global:
             yield str(subnet)
 
 
@@ -130,10 +124,10 @@ def rescan_unresponsive():
 if __name__ == "__main__":
     db_operations.check_connection()
     t1 = threading.Thread(target=daily_scan, name="DailyScanThread")
-    # t2 = threading.Thread(target=rescan_unresponsive,
-    #                       name="RescanUnresponsiveThread")
+    t2 = threading.Thread(target=rescan_unresponsive,
+                          name="RescanUnresponsiveThread")
 
     t1.start()
-    # t2.start()
+    t2.start()
     t1.join()
-    # t2.join()
+    t2.join()


### PR DESCRIPTION
Updated generate_public_ipv4_ranges_stream to remove exclusions for private, loopback, link-local, multicast, and reserved networks. Now relies solely on IPv4Network.is_global, potentially including ranges previously filtered out

### Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



## Testing
### Test Coverage
- [ ] Unit Tests Added
- [ ] Integration Tests Added
- [x] Manual Testing Performed

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] All tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [x] Any dependent changes have been merged and published

